### PR TITLE
🐛 fix: fixing check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,13 +37,13 @@ jobs:
         with:
           version: "18.1.8"
 
-      - name: Install libtinfo6 (Linux)
+      - name: Install libtinfo5 (Linux)
         if: contains(matrix.os, 'ubuntu')
         run: |
-          sudo add-apt-repository universe
-          sudo add-apt-repository multiverse
           sudo apt-get update
-          sudo apt-get install -y libtinfo5
+          wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.2-0ubuntu2.1_amd64.deb
+          sudo dpkg -i libtinfo5_6.2-0ubuntu2.1_amd64.deb
+          sudo apt-get install -f
 
       - name: Compile cpp code
         run: clang++ -shared -fPIC -o python_src/lego/libkey.so python_src/lego/key/key.cpp

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libtinfo6
+          sudo apt-get install -y libncurses5
 
       - name: Compile cpp code
         run: clang++ -shared -fPIC -o python_src/lego/libkey.so python_src/lego/key/key.cpp

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Install libtinfo6 (Linux)
         if: contains(matrix.os, 'ubuntu')
         run: |
+          sudo add-apt-repository universe
           sudo apt-get update
-          sudo apt-get install -y libncurses5
+          sudo apt-get install -y libtinfo5
 
       - name: Compile cpp code
         run: clang++ -shared -fPIC -o python_src/lego/libkey.so python_src/lego/key/key.cpp

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,11 +37,11 @@ jobs:
         with:
           version: "18.1.8"
 
-      - name: Install libtinfo5 (Linux)
+      - name: Install libtinfo6 (Linux)
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libtinfo5
+          sudo apt-get install -y libtinfo6
 
       - name: Compile cpp code
         run: clang++ -shared -fPIC -o python_src/lego/libkey.so python_src/lego/key/key.cpp

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo add-apt-repository universe
+          sudo add-apt-repository multiverse
           sudo apt-get update
           sudo apt-get install -y libtinfo5
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the check workflow to install libtinfo6 instead of libtinfo5 on Ubuntu systems.